### PR TITLE
ENTESB-12847 Remove the apps/v1beta1 commit from sb1, only needed for sb2

### DIFF
--- a/src/main/fabric8/statefulset.yml
+++ b/src/main/fabric8/statefulset.yml
@@ -1,4 +1,3 @@
-apiVersion: apps/v1
 spec:
   podManagementPolicy: Parallel
   updateStrategy:


### PR DESCRIPTION
This reverts commit 46605966258707f123a9814b23d168a05436787a.

See https://issues.redhat.com/browse/ENTESB-12847 and https://issues.redhat.com/browse/ENTESB-12089 for history.